### PR TITLE
[T12] UserContext moved to rest module & some processors updated to match the new changes

### DIFF
--- a/api/src/main/java/com/tinqinacademy/authenticationservice/api/operations/changepassword/ChangePasswordInput.java
+++ b/api/src/main/java/com/tinqinacademy/authenticationservice/api/operations/changepassword/ChangePasswordInput.java
@@ -1,5 +1,6 @@
 package com.tinqinacademy.authenticationservice.api.operations.changepassword;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tinqinacademy.authenticationservice.api.base.OperationInput;
 import com.tinqinacademy.authenticationservice.api.validation.user.password.PasswordRegex;
 import jakarta.validation.constraints.Email;
@@ -21,4 +22,9 @@ public class ChangePasswordInput implements OperationInput {
     @NotBlank
     @Email
     private String email;
+
+    @JsonIgnore
+    private String userContextOldPassword;
+    @JsonIgnore
+    private String userContextEmail;
 }

--- a/api/src/main/java/com/tinqinacademy/authenticationservice/api/operations/demote/DemoteInput.java
+++ b/api/src/main/java/com/tinqinacademy/authenticationservice/api/operations/demote/DemoteInput.java
@@ -1,5 +1,6 @@
 package com.tinqinacademy.authenticationservice.api.operations.demote;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tinqinacademy.authenticationservice.api.base.OperationInput;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
@@ -15,4 +16,7 @@ public class DemoteInput implements OperationInput {
     @NotBlank
     @UUID
     private String userId;
+
+    @JsonIgnore
+    private java.util.UUID userContextId;
 }

--- a/api/src/main/java/com/tinqinacademy/authenticationservice/api/operations/logout/LogoutInput.java
+++ b/api/src/main/java/com/tinqinacademy/authenticationservice/api/operations/logout/LogoutInput.java
@@ -1,5 +1,6 @@
 package com.tinqinacademy.authenticationservice.api.operations.logout;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tinqinacademy.authenticationservice.api.base.OperationInput;
 import lombok.*;
 
@@ -7,7 +8,11 @@ import lombok.*;
 @Getter
 @Setter
 @ToString
-//@AllArgsConstructor
+@AllArgsConstructor
 @NoArgsConstructor
 public class LogoutInput implements OperationInput {
+    @JsonIgnore
+    private String jwt;
+    @JsonIgnore
+    private String userContextId;
 }

--- a/api/src/main/java/com/tinqinacademy/authenticationservice/api/operations/promote/PromoteInput.java
+++ b/api/src/main/java/com/tinqinacademy/authenticationservice/api/operations/promote/PromoteInput.java
@@ -1,5 +1,6 @@
 package com.tinqinacademy.authenticationservice.api.operations.promote;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tinqinacademy.authenticationservice.api.base.OperationInput;
 import jakarta.validation.constraints.NotBlank;
 import lombok.*;
@@ -15,4 +16,7 @@ public class PromoteInput implements OperationInput {
     @NotBlank
     @UUID
     private String userId;
+
+    @JsonIgnore
+    private java.util.UUID userContextId;
 }

--- a/core/src/main/java/com/tinqinacademy/authenticationservice/core/operations/DemoteOperationProcessor.java
+++ b/core/src/main/java/com/tinqinacademy/authenticationservice/core/operations/DemoteOperationProcessor.java
@@ -8,7 +8,6 @@ import com.tinqinacademy.authenticationservice.api.operations.demote.DemoteOpera
 import com.tinqinacademy.authenticationservice.api.operations.demote.DemoteOutput;
 import com.tinqinacademy.authenticationservice.core.exceptions.ExceptionService;
 import com.tinqinacademy.authenticationservice.core.utils.LoggingUtils;
-import com.tinqinacademy.authenticationservice.persistence.model.context.UserContext;
 import com.tinqinacademy.authenticationservice.persistence.model.entity.User;
 import com.tinqinacademy.authenticationservice.persistence.model.enums.Role;
 import com.tinqinacademy.authenticationservice.persistence.repository.UserRepository;
@@ -25,12 +24,10 @@ import java.util.UUID;
 @Service
 public class DemoteOperationProcessor extends BaseOperationProcessor implements DemoteOperation {
 
-    private final UserContext userContext;
     private final UserRepository userRepository;
 
-    public DemoteOperationProcessor(ConversionService conversionService, ExceptionService exceptionService, Validator validator, UserContext userContext, UserRepository userRepository) {
+    public DemoteOperationProcessor(ConversionService conversionService, ExceptionService exceptionService, Validator validator, UserRepository userRepository) {
         super(conversionService, exceptionService, validator);
-        this.userContext = userContext;
         this.userRepository = userRepository;
     }
 
@@ -60,7 +57,7 @@ public class DemoteOperationProcessor extends BaseOperationProcessor implements 
         User userForDemotion = userRepository.findById(UUID.fromString(input.getUserId()))
                 .orElseThrow(() -> new NotFoundException(String.format("User with id: %s doesn't exist.", input.getUserId())));
 
-        if (userForDemotion.getId().equals(userContext.getCurrAuthorizedUser().getId())) {
+        if (userForDemotion.getId().equals(input.getUserContextId())) {
             throw new DemotionException("You cannot demote yourself.");
         }
 

--- a/core/src/main/java/com/tinqinacademy/authenticationservice/core/operations/LogoutOperationProcessor.java
+++ b/core/src/main/java/com/tinqinacademy/authenticationservice/core/operations/LogoutOperationProcessor.java
@@ -7,7 +7,6 @@ import com.tinqinacademy.authenticationservice.api.operations.logout.LogoutOutpu
 import com.tinqinacademy.authenticationservice.core.exceptions.ExceptionService;
 import com.tinqinacademy.authenticationservice.core.utils.JwtBlacklistCacheService;
 import com.tinqinacademy.authenticationservice.core.utils.LoggingUtils;
-import com.tinqinacademy.authenticationservice.persistence.model.context.UserContext;
 import io.vavr.control.Either;
 import io.vavr.control.Try;
 import jakarta.validation.Validator;
@@ -20,21 +19,19 @@ import org.springframework.stereotype.Service;
 public class LogoutOperationProcessor extends BaseOperationProcessor implements LogoutOperation {
 
     private final JwtBlacklistCacheService jwtBlacklist;
-    private final UserContext userContext;
 
-    public LogoutOperationProcessor(ConversionService conversionService, ExceptionService exceptionService, Validator validator, JwtBlacklistCacheService jwtBlacklist, UserContext userContext) {
+    public LogoutOperationProcessor(ConversionService conversionService, ExceptionService exceptionService, Validator validator, JwtBlacklistCacheService jwtBlacklist) {
         super(conversionService, exceptionService, validator);
         this.jwtBlacklist = jwtBlacklist;
-        this.userContext = userContext;
     }
 
     @Override
     public Either<Errors, LogoutOutput> process(LogoutInput input) {
         return Try.of(() -> {
                     log.info(String.format("Start %s %s input: %s", this.getClass().getSimpleName(), LoggingUtils.getMethodName(), input));
+                    validate(input);
 
-                    String jwt = userContext.getJwt();
-                    jwtBlacklist.addToCache(jwt, userContext.getCurrAuthorizedUser().getId());
+                    jwtBlacklist.addToCache(input.getJwt(), input.getUserContextId());
                     LogoutOutput output = LogoutOutput.builder().build();
 
                     log.info(String.format("End %s %s output: %s", this.getClass().getSimpleName(), LoggingUtils.getMethodName(), output));

--- a/core/src/main/java/com/tinqinacademy/authenticationservice/core/operations/PromoteOperationProcessor.java
+++ b/core/src/main/java/com/tinqinacademy/authenticationservice/core/operations/PromoteOperationProcessor.java
@@ -8,7 +8,6 @@ import com.tinqinacademy.authenticationservice.api.operations.promote.PromoteOpe
 import com.tinqinacademy.authenticationservice.api.operations.promote.PromoteOutput;
 import com.tinqinacademy.authenticationservice.core.exceptions.ExceptionService;
 import com.tinqinacademy.authenticationservice.core.utils.LoggingUtils;
-import com.tinqinacademy.authenticationservice.persistence.model.context.UserContext;
 import com.tinqinacademy.authenticationservice.persistence.model.entity.User;
 import com.tinqinacademy.authenticationservice.persistence.model.enums.Role;
 import com.tinqinacademy.authenticationservice.persistence.repository.UserRepository;
@@ -25,12 +24,10 @@ import java.util.UUID;
 @Service
 public class PromoteOperationProcessor extends BaseOperationProcessor implements PromoteOperation {
 
-    private final UserContext userContext;
     private final UserRepository userRepository;
 
-    public PromoteOperationProcessor(ConversionService conversionService, ExceptionService exceptionService, Validator validator, UserContext userContext, UserRepository userRepository) {
+    public PromoteOperationProcessor(ConversionService conversionService, ExceptionService exceptionService, Validator validator, UserRepository userRepository) {
         super(conversionService, exceptionService, validator);
-        this.userContext = userContext;
         this.userRepository = userRepository;
     }
 
@@ -60,7 +57,7 @@ public class PromoteOperationProcessor extends BaseOperationProcessor implements
         User userForPromotion = userRepository.findById(UUID.fromString(input.getUserId()))
                 .orElseThrow(() -> new NotFoundException(String.format("User with id: %s doesn't exist", input.getUserId())));
 
-        if (userForPromotion.getId().equals(userContext.getCurrAuthorizedUser().getId())) {
+        if (userForPromotion.getId().equals(input.getUserContextId())) {
             throw new PromotionException("You cannot promote yourself to admin, because you are admin.");
         }
 

--- a/core/src/main/java/com/tinqinacademy/authenticationservice/core/utils/JwtBlacklistCacheService.java
+++ b/core/src/main/java/com/tinqinacademy/authenticationservice/core/utils/JwtBlacklistCacheService.java
@@ -2,6 +2,7 @@ package com.tinqinacademy.authenticationservice.core.utils;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.stereotype.Service;
@@ -11,9 +12,11 @@ import org.springframework.stereotype.Service;
 public class JwtBlacklistCacheService {
 
     private final CacheManager cacheManager;
+    @Value("${env.JWT_BLACKLIST}")
+    private String JWT_BLACKLIST;
 
     private Cache<Object, Object> getCaffeineCache() {
-        org.springframework.cache.Cache springCache = cacheManager.getCache("jwtBlacklist");
+        org.springframework.cache.Cache springCache = cacheManager.getCache(JWT_BLACKLIST);
         if (springCache instanceof CaffeineCache) {
             return ((CaffeineCache) springCache).getNativeCache();
         }

--- a/persistence/src/main/java/com/tinqinacademy/authenticationservice/persistence/model/context/UserContext.java
+++ b/persistence/src/main/java/com/tinqinacademy/authenticationservice/persistence/model/context/UserContext.java
@@ -2,15 +2,18 @@ package com.tinqinacademy.authenticationservice.persistence.model.context;
 
 import com.tinqinacademy.authenticationservice.persistence.model.entity.User;
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.annotation.RequestScope;
 
 @Getter
-@Setter
 @Component
 @RequestScope
 public class UserContext {
     private User currAuthorizedUser;
     private String jwt;
+
+    public void setContext(User user, String jwt){
+        this.currAuthorizedUser = user;
+        this.jwt = jwt;
+    }
 }

--- a/rest/src/main/java/com/tinqinacademy/authenticationservice/rest/config/CaffeineCacheConfig.java
+++ b/rest/src/main/java/com/tinqinacademy/authenticationservice/rest/config/CaffeineCacheConfig.java
@@ -2,6 +2,7 @@ package com.tinqinacademy.authenticationservice.rest.config;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
@@ -13,10 +14,15 @@ import java.util.Collections;
 @Configuration
 public class CaffeineCacheConfig {
 
+    @Value("${env.JWT_BLACKLIST}")
+    private String JWT_BLACKLIST;
+    @Value("${env.JWT_BLACKLIST_DURATION}")
+    private static int JWT_BLACKLIST_DURATION;
+
     @Bean
     public CacheManager cacheManager() {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager();
-        cacheManager.registerCustomCache("jwtBlacklist", jwtBlacklist());
+        cacheManager.registerCustomCache(JWT_BLACKLIST, jwtBlacklist());
 
         //! To avoid dynamic caches and be sure each name is assigned to a specific config (dynamic = false)
         //! throws error when tries to use a new cache
@@ -27,7 +33,7 @@ public class CaffeineCacheConfig {
 
     private static Cache<Object,Object> jwtBlacklist() {
         return Caffeine.newBuilder()
-                .expireAfterWrite(Duration.ofMinutes(5))
+                .expireAfterWrite(Duration.ofMinutes(JWT_BLACKLIST_DURATION))
                 .build();
     }
 

--- a/rest/src/main/java/com/tinqinacademy/authenticationservice/rest/interceptors/AccessInterceptor.java
+++ b/rest/src/main/java/com/tinqinacademy/authenticationservice/rest/interceptors/AccessInterceptor.java
@@ -2,7 +2,7 @@ package com.tinqinacademy.authenticationservice.rest.interceptors;
 
 import com.tinqinacademy.authenticationservice.api.RestApiRoutes;
 import com.tinqinacademy.authenticationservice.core.security.JwtService;
-import com.tinqinacademy.authenticationservice.persistence.model.context.UserContext;
+import com.tinqinacademy.authenticationservice.rest.security.UserContext;
 import com.tinqinacademy.authenticationservice.persistence.model.entity.User;
 import com.tinqinacademy.authenticationservice.persistence.model.enums.Role;
 import jakarta.servlet.http.HttpServletRequest;

--- a/rest/src/main/java/com/tinqinacademy/authenticationservice/rest/security/UserContext.java
+++ b/rest/src/main/java/com/tinqinacademy/authenticationservice/rest/security/UserContext.java
@@ -1,4 +1,4 @@
-package com.tinqinacademy.authenticationservice.persistence.model.context;
+package com.tinqinacademy.authenticationservice.rest.security;
 
 import com.tinqinacademy.authenticationservice.persistence.model.entity.User;
 import lombok.Getter;


### PR DESCRIPTION
I have moved UserContext from persistence to rest module. I inject it now inside the controllers which extract certain data from it and set the data into the inputs. So it is removed from the processors. The processors now again use data from UserContext, but do it via the inputs, which are configured in the controllers.